### PR TITLE
Add CI, issue templates and labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Report something that isn't working
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Ubuntu]
+ - Node version [e.g. 20]
+ - Browser [if applicable]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest a new idea or improvement
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,14 @@
+---
+name: Improvement
+about: Suggest an improvement to existing features or docs
+labels: improvement
+---
+
+**What needs improving?**
+Describe the current behavior and how it could be improved.
+
+**Proposed solution**
+Describe the changes you'd like to see.
+
+**Additional context**
+Add any other context or screenshots about the suggestion here.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,16 @@
+labels:
+  - name: bug
+    color: ff0000
+    description: Something isn't working
+  - name: enhancement
+    color: a2eeef
+    description: New feature or request
+  - name: improvement
+    color: c2e0c6
+    description: Enhancement to existing functionality or docs
+  - name: documentation
+    color: 0075ca
+    description: Documentation related work
+  - name: hft
+    color: 5319e7
+    description: Core high-frequency trading code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run check

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,13 @@
+name: Sync Labels
+
+on:
+  workflow_dispatch:
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-ecosystem/action-create-labels@v1
+        with:
+          config-file: .github/labels.yml

--- a/code/README.md
+++ b/code/README.md
@@ -1,0 +1,3 @@
+# HFT Core Code
+
+This directory will contain the Rust code for the high-frequency trading framework. Implementations will be added incrementally.


### PR DESCRIPTION
## Summary
- add issue templates for bugs, features and improvements
- provide default label set and workflow to sync labels
- create CI workflow running `npm run check`
- add placeholder directory for HFT code

## Testing
- `npm ci`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6885e0ffae8883249548b8564033990e